### PR TITLE
Invite Command Fix / Gang ownership fix

### DIFF
--- a/src/CS2/Commands/Gang/InviteCommand.cs
+++ b/src/CS2/Commands/Gang/InviteCommand.cs
@@ -37,6 +37,13 @@ public class InviteCommand(IServiceProvider provider)
 
     if (!perms.Permissions.HasFlag(Perm.INVITE_OTHERS))
       return await handleNoPermission(player, info);
+    
+    var invites =
+      await GangStats.GetForGang<InvitationData>(player.GangId.Value,
+        gangInviteId) ?? new InvitationData();
+
+    if (info[1].Equals("cancel", StringComparison.OrdinalIgnoreCase))
+      return await handleCancelInvite(info, player, invites);
 
     var capacityPerk = Provider.GetService<ICapacityPerk>();
     if (capacityPerk != null) {
@@ -49,13 +56,6 @@ public class InviteCommand(IServiceProvider provider)
         return CommandResult.ERROR;
       }
     }
-
-    var invites =
-      await GangStats.GetForGang<InvitationData>(player.GangId.Value,
-        gangInviteId) ?? new InvitationData();
-
-    if (info[1].Equals("cancel", StringComparison.OrdinalIgnoreCase))
-      return await handleCancelInvite(info, player, invites);
 
     return await handleInvite(executor, player, info, invites);
   }

--- a/src/CS2/Commands/Gang/TransferCommand.cs
+++ b/src/CS2/Commands/Gang/TransferCommand.cs
@@ -55,7 +55,9 @@ public class TransferCommand(IServiceProvider provider)
     var targetRank = await Ranks.GetRank(target)
       ?? throw new GangException("Target does not have a rank.");
 
-    if (targetRank != immediatelyLower) {
+    // Debug code
+    info.ReplySync($"Expected rank value: {immediatelyLower.Rank}, Target rank value: {targetRank.Rank}");
+    if (targetRank.Rank != immediatelyLower.Rank) {
       info.ReplySync(Locale.Get(MSG.COMMAND_TRANSFER_SUBORDINATE,
         immediatelyLower.Name));
       return CommandResult.SUCCESS;


### PR DESCRIPTION
Fixed cannot cancel gang invite when [invite] capacity is full bug by putting the cancel check before the capacity check